### PR TITLE
Add Messags To Article Test

### DIFF
--- a/test/models/article_test.rb
+++ b/test/models/article_test.rb
@@ -7,10 +7,10 @@ class ArticleTest < ActiveSupport::TestCase
 
   test "should not save article without required attributes" do
     article = Article.new
-    assert_not article.save
-    assert_not article.update title: "test_one" 
-    assert_not article.update body: "123456789"
+    assert_not article.save, "saved article without required attributes"
+    assert_not article.update(title: "test_one"), "saved article without required attributes"
+    assert_not article.update(body: "123456789"), "saved article without required attributes"
 
-    assert article.update body: "1234567890", status: "public"
+    assert article.update(body: "1234567890", status: "public"), "failed to save article with required attributes"
   end
 end


### PR DESCRIPTION
Article test do not have descriptive error messages for them.  I have always wanted to utilize them but have never taken the time but now I have time to do so.